### PR TITLE
fix: remove import throwing error

### DIFF
--- a/src/main/java/Stock/Stock.java
+++ b/src/main/java/Stock/Stock.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
-import javax.annotation.processing.Generated;
 import java.util.ArrayList;
 import java.util.Map;
 


### PR DESCRIPTION
I have removed an unused import in Stock.java, which threw an error, as this specific dependecy was not included in the gradle config